### PR TITLE
adding docker image repo from dockerhub

### DIFF
--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -1,13 +1,13 @@
 {
   "AWSEBDockerrunVersion": "1",
   "Image": {
-    "Name": "YOUR-DOCKER-HUB-ID/YOUR-IMAGE-NAME",
+    "Name": "jw59615/labs_image",
     "Update": "true"
   },
   "Ports": [
     {
       "ContainerPort": "8000"
     }
-  ], 
+  ],
   "Command": "uvicorn app.main:app --workers 1 --host 0.0.0.0 --port 8000"
 }


### PR DESCRIPTION
This PR is to change the default line in the template to reflect the Docker Image that is going to be used to deploy on AWS. 

DockerHub Image Link(will be updated before deploy):
[https://hub.docker.com/repository/docker/jw59615/labs_image](https://hub.docker.com/repository/docker/jw59615/labs_image)

Signed-off-by: Jwilson1172 <jw59615@gmail.com>