### PR TITLE
Added commentary on human errors

### DIFF
--- a/notebooks/transcription_confidence.ipynb
+++ b/notebooks/transcription_confidence.ipynb
@@ -483,6 +483,19 @@
    ]
   },
   {
+   "source": [
+    "### Some stories had missing pages for the human transcription which resulted in inaccurate error calculations. Those were dropped below.\n",
+    "### Additionally, we found the following human transcription errors. We believe this was a small enough sample size that it didn't affect the correlation too much. But they are important to keep in mind so I will note them here for future iterations.\n",
+    "- Story 5202: There is text added to a sentence by the child using a ^. It is placed out of order. There are also a few '[]' throughout the transcription. One is for something that is crossed out. The others are smudges on the paper. Typo 'Jlack' instead of 'Jack' on the second page.\n",
+    "- Story 3109: Text added by ^ is out of place. Includes some text from an illustration. [] brackets where words are crossd out. \n",
+    "- Story 3114: Carrot out of place\n",
+    "\n",
+    "The convention seems to be the text associated with a carrot (^) where the student is adding to a sentence is out of order. Words that are crossed out are indicated by []. Sometimes text in illustrations are included but most times they are not. The human transcriptions errors do not seem too drastic to affect the calculated errors. \n"
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 201,
    "metadata": {},
@@ -1142,13 +1155,6 @@
    "source": [
     "df_25_character_submission.corr()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ]
 }


### PR DESCRIPTION
# Description

Added a paragraph in my notebook that discusses specific errors we found in the human transcriptions. Mostly for the purposes of future teams that may be looking through the notebook. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

## Has This Been Tested

- [ ] Yes
- [ ] No
- [x] Not necessary

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
